### PR TITLE
Import LiveReload properly

### DIFF
--- a/CoffeescriptPlugin.py
+++ b/CoffeescriptPlugin.py
@@ -8,11 +8,11 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
 
 
 class CoffeeThread(threading.Thread):
@@ -20,10 +20,10 @@ class CoffeeThread(threading.Thread):
     def getLocalOverride(self):
         """
         You can override defaults in sublime-project file
-        
+
         Discussion: https://github.com/dz0ny/LiveReload-sublimetext2/issues/43
-        
-        Example: 
+
+        Example:
 
             "settings": {
               "coffee": {

--- a/CompassPlugin.py
+++ b/CompassPlugin.py
@@ -9,11 +9,10 @@ import sublime
 import sublime_plugin
 import shlex
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 
 class CompassThread(threading.Thread):

--- a/LESSPlugin.py
+++ b/LESSPlugin.py
@@ -8,11 +8,10 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 
 class LessThread(threading.Thread):
@@ -20,10 +19,10 @@ class LessThread(threading.Thread):
     def getLocalOverride(self):
         """
         You can override defaults in sublime-project file
-        
+
         Discussion: https://github.com/dz0ny/LiveReload-sublimetext2/issues/43
-        
-        Example: 
+
+        Example:
 
             "settings": {
               "lesscompass": {

--- a/SimpleReloadCallback.py
+++ b/SimpleReloadCallback.py
@@ -6,11 +6,10 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 ##Modlue name must be the same as class or else callbacks won't work
 class SimpleReloadCallback(LiveReload.Plugin):

--- a/SimpleReloadPlugin.py
+++ b/SimpleReloadPlugin.py
@@ -6,11 +6,10 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 
 class SimpleRefresh(LiveReload.Plugin, sublime_plugin.EventListener):

--- a/SimpleReloadPluginDelay.py
+++ b/SimpleReloadPluginDelay.py
@@ -6,11 +6,10 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 
 class SimpleRefreshDelay(LiveReload.Plugin, sublime_plugin.EventListener):

--- a/SimpleWSCallback.py
+++ b/SimpleWSCallback.py
@@ -6,11 +6,10 @@ import sys
 import sublime
 import sublime_plugin
 
-# fix for import order
-
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 ##Modlue name must be the same as class or else callbacks won't work
 class SimpleWSCallback(LiveReload.Plugin, sublime_plugin.EventListener):
@@ -26,6 +25,6 @@ class SimpleWSCallback(LiveReload.Plugin, sublime_plugin.EventListener):
         region = sublime.Region(0, view.size())
         source = view.substr(region)
         self.sendRaw("socket", source)
-        
+
     def onReceive(self, data, origin):
       print(data)

--- a/snippets/livereload_plugin.sublime-snippet
+++ b/snippets/livereload_plugin.sublime-snippet
@@ -7,10 +7,11 @@
 import sublime
 import sublime_plugin
 import os
-#fix for import order
-sys.path.append(os.path.join(sublime.packages_path(), 'LiveReload'))
-LiveReload = __import__('LiveReload')
-sys.path.remove(os.path.join(sublime.packages_path(), 'LiveReload'))
+
+if int(sublime.version()) < 3000:
+    import LiveReload
+else:
+    from . import LiveReload
 
 class MarkdownLiveReloadP(LiveReload.Plugin,
     sublime_plugin.EventListener):


### PR DESCRIPTION
Old version screwed up Sublime Text's module and path management by
overriding `sys.modules["LiveReload"]`, representing the entire package
folder, with just the `LiveReload.py` module.

Plugins from other packages (i.e. not bundled in this package) should
be using "from LiveReload import LiveReload" in ST3. In ST2,
cross-package imports are not possible without `sys.path` interference.

See also https://github.com/wbond/package_control_channel/pull/4503.

Note: This obviously does not restrict LiveReload plugins that are saved in a different package. I am unsure about whetehr the snippet is intended to be used for plugins that are saved inside the LiveReload package or in another package. In the latter case, it should be changed to `from LiveReload import LiveReload`, which is ST3 only. ST2 would, again, require the sys.path hack.